### PR TITLE
Add HTML box widgets

### DIFF
--- a/rd_ui/app/scripts/controllers/dashboard.js
+++ b/rd_ui/app/scripts/controllers/dashboard.js
@@ -129,7 +129,7 @@
     };
   };
 
-  var WidgetCtrl = function($scope, $location, Events, Query) {
+  var WidgetCtrl = function($scope, $sce, $location, Events, Query) {
     $scope.deleteWidget = function() {
       if (!confirm('Are you sure you want to remove "' + $scope.widget.getName() + '" from the dashboard?')) {
         return;
@@ -164,6 +164,11 @@
       $scope.type = 'visualization';
     } else if ($scope.widget.restricted) {
       $scope.type = 'restricted';
+    } else if ($scope.widget.options.html) {
+      $scope.type = 'htmlbox';
+      $scope.rawHtml = function() {
+        return $sce.trustAsHtml($scope.widget.text);
+      }
     } else {
       $scope.type = 'textbox';
     }
@@ -171,6 +176,6 @@
 
   angular.module('redash.controllers')
     .controller('DashboardCtrl', ['$scope', 'Events', 'Widget', '$routeParams', '$location', '$http', '$timeout', '$q', 'Dashboard', DashboardCtrl])
-    .controller('WidgetCtrl', ['$scope', '$location', 'Events', 'Query', WidgetCtrl])
+    .controller('WidgetCtrl', ['$scope', '$sce', '$location', 'Events', 'Query', WidgetCtrl])
 
 })();

--- a/rd_ui/app/scripts/directives/dashboard_directives.js
+++ b/rd_ui/app/scripts/directives/dashboard_directives.js
@@ -109,8 +109,8 @@
     }
   ]);
 
-  directives.directive('newWidgetForm', ['Query', 'Widget', 'growl',
-    function(Query, Widget, growl) {
+  directives.directive('newWidgetForm', ['Query', 'Widget', 'growl', '$sce',
+    function(Query, Widget, growl, $sce) {
       return {
         restrict: 'E',
         scope: {
@@ -127,6 +127,10 @@
             value: 2
           }];
 
+          $scope.rawHtml = function() {
+            return $sce.trustAsHtml($scope.text);
+          }
+
           $scope.type = 'visualization';
 
           $scope.isVisualization = function () {
@@ -137,12 +141,19 @@
             return $scope.type == 'textbox';
           };
 
+          $scope.isHtmlBox = function () {
+            return $scope.type == 'htmlbox';
+          };
+
           $scope.setType = function (type) {
             $scope.type = type;
             if (type == 'textbox') {
               $scope.widgetSizes.push({name: 'Hidden', value: 0});
             } else if ($scope.widgetSizes.length > 2) {
               $scope.widgetSizes.pop();
+            }
+            if (type == 'htmlbox') {
+              $scope.options.html = true;
             }
           };
 
@@ -153,6 +164,7 @@
             $scope.query = {};
             $scope.selected_query = undefined;
             $scope.text = "";
+            $scope.options = {};
           };
 
           reset();
@@ -191,7 +203,7 @@
             var widget = new Widget({
               'visualization_id': $scope.selectedVis && $scope.selectedVis.id,
               'dashboard_id': $scope.dashboard.id,
-              'options': {},
+              'options': $scope.options,
               'width': $scope.widgetSize,
               'text': $scope.text
             });

--- a/rd_ui/app/views/dashboard.html
+++ b/rd_ui/app/views/dashboard.html
@@ -87,6 +87,21 @@
                     </div>
                 </div>
             </div>
+
+            <div class="panel panel-default rd-widget-textbox" ng-hide="widget.width == 0" ng-if="type=='htmlbox'" ng-mouseenter="showControls = true" ng-mouseleave="showControls = false">
+                <div class="panel-body">
+                    <div class="row">
+                        <div class="col-lg-11">
+                            <p ng-bind-html="rawHtml()"></p>
+                        </div>
+                        <div class="col-lg-1">
+                          <span class="pull-right" ng-show="showControls">
+                              <button type="button" class="btn btn-default btn-xs" ng-show="dashboard.canEdit()" ng-click="deleteWidget()" title="Remove Widget"><span class="glyphicon glyphicon-trash"></span></button>
+                          </span>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 </div>

--- a/rd_ui/app/views/new_widget_form.html
+++ b/rd_ui/app/views/new_widget_form.html
@@ -9,6 +9,7 @@
                 <p class="btn-group">
                     <button type="button" class="btn btn-default" ng-class="{active: isVisualization()}" ng-click="setType('visualization')">Visualization</button>
                     <button type="button" class="btn btn-default" ng-class="{active: isTextBox()}" ng-click="setType('textbox')">Text Box</button>
+                    <button type="button" class="btn btn-default" ng-class="{active: isHtmlBox()}" ng-click="setType('htmlbox')">HTML Box</button>
                 </p>
 
                 <div ng-show="isTextBox()">
@@ -18,6 +19,16 @@
                     <div ng-show="text">
                         <strong>Preview:</strong>
                         <p ng-bind-html="text | markdown"></p>
+                    </div>
+                </div>
+
+                <div ng-show="isHtmlBox()">
+                    <div class="form-group">
+                        <textarea class="form-control" ng-model="text" rows="3"></textarea>
+                    </div>
+                    <div ng-show="text">
+                        <strong>Preview:</strong>
+                        <p ng-bind-html="rawHtml()"></p>
                     </div>
                 </div>
 
@@ -50,7 +61,7 @@
 
             <div class="modal-footer">
                 <button type="button" class="btn btn-default" ng-disabled="saveInProgress" data-dismiss="modal">Close</button>
-                <button type="button" class="btn btn-primary" ng-disabled="saveInProgress || !(selectedVis || isTextBox())" ng-click="saveWidget()">Add to Dashboard</button>
+                <button type="button" class="btn btn-primary" ng-disabled="saveInProgress || !(selectedVis || isTextBox() || isHtmlBox())" ng-click="saveWidget()">Add to Dashboard</button>
             </div>
         </div>
         <!-- /.modal-content -->


### PR DESCRIPTION
This adds a new dashboard widget type, "HTML Box", which displays raw HTML. We could use this to add forms that submit parameters, or anything else that uses HTML to make dashboards more useful.
